### PR TITLE
Use more lightweight library for parsing/handling JSON data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,6 @@ buildNumber.properties
 .classpath
 
 # End of https://www.toptal.com/developers/gitignore/api/java,maven,intellij
+
+# Exclude vscode Workspace configuration
+.vscode/

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dev.respark.licensegate</groupId>
     <artifactId>license-gate</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.4</version>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>dev.respark.licensegate</groupId>
@@ -24,11 +24,11 @@
 
 
     <dependencies>
-        <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-core -->
+        <!-- https://mvnrepository.com/artifact/org.json/json -->
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>2.16.1</version>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20240303</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
As per request by a user in discord, the library currently uses fasterxml-jackson databind, which in itself is likely too large for a library with this little volume, especially when this library is required to be shaded/exported into the final jar users will export.

![image](https://github.com/DevLeoko/license-gate-java-wrapper/assets/47116705/1c9cbaaf-3ee3-41bd-83ea-f5eda582101b)

Replacing said jackson-core databind with a more lightweight library, org.json:

![image](https://github.com/DevLeoko/license-gate-java-wrapper/assets/47116705/a6ba9cb9-96fd-44a7-a106-3114c8fad2aa)

Tested locally using the already existing "LocalTesting.java", works as well as before.

